### PR TITLE
Added support of lines of obj model formal

### DIFF
--- a/src/main/java/ben_mkiv/rendertoolkit/common/widgets/component/common/OBJModelOC.java
+++ b/src/main/java/ben_mkiv/rendertoolkit/common/widgets/component/common/OBJModelOC.java
@@ -4,6 +4,8 @@ import ben_mkiv.rendertoolkit.common.widgets.IRenderableWidget;
 import ben_mkiv.rendertoolkit.common.widgets.RenderType;
 import ben_mkiv.rendertoolkit.common.widgets.WidgetGLWorld;
 import ben_mkiv.rendertoolkit.common.widgets.component.wavefrontObj.Face;
+import ben_mkiv.rendertoolkit.common.widgets.component.wavefrontObj.PolyLine;
+import ben_mkiv.rendertoolkit.common.widgets.component.wavefrontObj.Vertex;
 import ben_mkiv.rendertoolkit.common.widgets.component.wavefrontObj.objParser;
 import ben_mkiv.rendertoolkit.common.widgets.core.attribute.IOBJModel;
 import com.google.common.base.Charsets;
@@ -11,6 +13,7 @@ import io.netty.buffer.ByteBuf;
 import net.minecraft.client.renderer.BufferBuilder;
 import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.client.renderer.Tessellator;
+import net.minecraft.client.renderer.vertex.DefaultVertexFormats;
 import net.minecraft.client.renderer.vertex.VertexFormat;
 import net.minecraft.client.renderer.vertex.VertexFormatElement;
 import net.minecraft.entity.player.EntityPlayer;
@@ -19,6 +22,7 @@ import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 import org.lwjgl.opengl.GL11;
 
+import java.awt.*;
 import java.util.List;
 
 public abstract class OBJModelOC extends WidgetGLWorld implements IOBJModel {
@@ -103,12 +107,32 @@ public abstract class OBJModelOC extends WidgetGLWorld implements IOBJModel {
                 TESR.draw();
             }
 
+            int r = (color >> 16) & 0xFF;
+            int g = (color >> 8) & 0xFF;
+            int b = color & 0xFF;
+            int a = (color >> 24) & 0xff;
+
+            if (objFile.lines.size() > 0) {
+                buffer.begin(GL11.GL_LINES, DefaultVertexFormats.POSITION_COLOR);
+                readPolylineList(objFile.lines, r, g, b, a);
+                TESR.draw();
+            }
+
             this.postRender();
         }
 
         public void renderList(List<Face> faces, int color){
             for (Face f : faces) for (int i = 0; i < f.getVertexes().length; i++) {
                 buffer.addVertexData(f.getVertexes()[i].setColor((color)).setAlpha((color >> 24)).getVertexData(malisisVertexFormat, null));
+        public void readPolylineList(List<PolyLine> lines, int r, int g, int b, int a) {
+            for (PolyLine line : lines) {
+                Vertex[] vertexes = line.getVertexes();
+                for (int i = 0; i < vertexes.length - 1; i++) {
+                    Vertex v1 = vertexes[i];
+                    Vertex v2 = vertexes[i + 1];
+                    buffer.pos(v1.getX(), v1.getY(), v1.getZ()).color(r, g, b, a).endVertex();
+                    buffer.pos(v2.getX(), v2.getY(), v2.getZ()).color(r, g, b, a).endVertex();
+                }
             }
         }
 

--- a/src/main/java/ben_mkiv/rendertoolkit/common/widgets/component/common/OBJModelOC.java
+++ b/src/main/java/ben_mkiv/rendertoolkit/common/widgets/component/common/OBJModelOC.java
@@ -121,9 +121,13 @@ public abstract class OBJModelOC extends WidgetGLWorld implements IOBJModel {
             this.postRender();
         }
 
-        public void renderList(List<Face> faces, int color){
-            for (Face f : faces) for (int i = 0; i < f.getVertexes().length; i++) {
-                buffer.addVertexData(f.getVertexes()[i].setColor((color)).setAlpha((color >> 24)).getVertexData(malisisVertexFormat, null));
+        public void renderList(List<Face> faces, int color) {
+            for (Face f : faces)
+                for (int i = 0; i < f.getVertexes().length; i++) {
+                    buffer.addVertexData(f.getVertexes()[i].setColor((color)).setAlpha((color >> 24)).getVertexData(malisisVertexFormat, null));
+
+                }
+        }
         public void readPolylineList(List<PolyLine> lines, int r, int g, int b, int a) {
             for (PolyLine line : lines) {
                 Vertex[] vertexes = line.getVertexes();

--- a/src/main/java/ben_mkiv/rendertoolkit/common/widgets/component/wavefrontObj/PolyLine.java
+++ b/src/main/java/ben_mkiv/rendertoolkit/common/widgets/component/wavefrontObj/PolyLine.java
@@ -1,0 +1,19 @@
+package ben_mkiv.rendertoolkit.common.widgets.component.wavefrontObj;
+
+import java.util.List;
+
+public class PolyLine {
+
+    Vertex[] vertexes;
+
+    public PolyLine(Vertex[] vertexes) {
+        this.vertexes = vertexes;
+    }
+
+    public PolyLine(List<Vertex> vertexes) {
+        this(vertexes.toArray(new Vertex[0]));
+    }
+    public Vertex[] getVertexes() {
+        return vertexes;
+    }
+}

--- a/src/main/java/ben_mkiv/rendertoolkit/common/widgets/component/wavefrontObj/objParser.java
+++ b/src/main/java/ben_mkiv/rendertoolkit/common/widgets/component/wavefrontObj/objParser.java
@@ -50,6 +50,8 @@ public class objParser
     protected static Pattern linePattern = Pattern.compile("^(?<type>.*?) (?<data>.*)$");
     /** Pattern for face data. */
     protected static Pattern facePattern = Pattern.compile("(?<v>\\d+)(/(?<t>\\d+)?(/(?<n>\\d+))?)?");
+    /** Pattern for polyline data. */
+    protected static Pattern polylinePattern = Pattern.compile("(?<v>\\d+)");
     /** Matcher object. */
     protected Matcher matcher;
     /** Current line being parsed. */
@@ -66,6 +68,7 @@ public class objParser
 
     public List<Face> facesTri = new ArrayList<>();
     public List<Face> facesQuad = new ArrayList<>();
+    public List<PolyLine> lines = new ArrayList<>();
 
     public objParser(String objData){
         load(objData);
@@ -108,6 +111,10 @@ public class objParser
                         case "g":
                         case "o":
                             addShape(data);
+                            break;
+
+                        case "l":
+                            addLine(data);
                             break;
 
                         default:
@@ -287,6 +294,33 @@ public class objParser
 
         if (data != "")
             currentShape = data.indexOf('_') != -1 ? data.substring(0, data.indexOf('_')) : data;
+    }
+
+    private void addLine(String data)
+    {
+        Matcher matcher = polylinePattern.matcher(data);
+
+        List<Vertex> lineVertex = new ArrayList<>();
+        String strV;
+        Vertex vertex;
+        int v = 0;
+
+        while (matcher.find())
+        {
+            strV = matcher.group("v");
+
+            v = Integer.parseInt(strV);
+            vertex = vertexes.get(v > 0 ? v - 1 : vertexes.size() - v - 1);
+
+            if (vertex != null)
+            {
+                lineVertex.add(new Vertex(vertex));
+            }
+            else {
+                Logger.getLogger(renderToolkit.MODID).info("[ObjFileImporter] Wrong vertex reference "+lineNumber+" for face at line "+currentLine);
+            }
+        }
+        lines.add(new PolyLine(lineVertex));
     }
 
     /**


### PR DESCRIPTION
This pr adds a support of lines according to
https://en.wikipedia.org/wiki/Wavefront_.obj_file#Line_elements
Related to https://github.com/Starchasers/OCGlasses/issues/102

3D
![image](https://user-images.githubusercontent.com/35610168/112039667-55a09380-8b55-11eb-9dbb-65b6fddf4996.png)

2D
![image](https://user-images.githubusercontent.com/35610168/112039800-81237e00-8b55-11eb-94b9-62d4f0bf4539.png)
